### PR TITLE
feat: add reusable custom button for form create and form upload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,7 @@ function App() {
                   {
                     name: "Properties",
                     list: "/properties",
-                    // create: "/blog-posts/create",
+                    create: "/properties/create",
                     // edit: "/blog-posts/edit/:id",
                     // show: "/blog-posts/show/:id",
                     meta: {
@@ -245,6 +245,7 @@ function App() {
                     </Route>      
                     <Route path="/properties">
                       <Route index element={<AllProperties />} />
+                      <Route path="create" element={<CreateProperties />} />
                     </Route>
                     <Route path="/agent">
                       <Route index element={<Agent />} />

--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -1,10 +1,50 @@
-import React from 'react'
+import { Button } from '@mui/material';
+import React, { ReactNode } from 'react'
 
-function CustomButton() {
+interface CustomButtonProps {
+  type?: string;
+  title: string;
+  backgroundColor: string;
+  color: string;
+  fullWidth?: boolean;
+  icon?: ReactNode;
+  disabled?: boolean;
+  handleClick?: () => void; 
+}
+
+const CustomButton = ({
+    type,
+    title,
+    backgroundColor,
+    color,
+    fullWidth,
+    icon,
+    disabled,
+    handleClick 
+}: CustomButtonProps) => {
   return (
-    <div>
-      
-    </div>
+    <Button
+    disabled={disabled}
+    type={type === "submit" ? "submit" : "button"}
+    sx={{
+      flex: fullWidth ? 1 : "unset",
+      padding: "10px 15px",
+      width: fullWidth ? "100%" : "unset",
+      backgroundColor,
+      color,
+      fontWeight: 600,
+      gap: "18px",
+      textTransform: "capitalize",
+      "&:hover":{
+        opacity: 0.9,
+        backgroundColor
+      }
+    }}
+    onClick={handleClick}
+    >
+      {icon}
+      {title}
+    </Button>
   )
 }
 

--- a/src/components/common/Form.tsx
+++ b/src/components/common/Form.tsx
@@ -1,10 +1,204 @@
-import React from 'react'
+import { Box, Button, FormControl, FormHelperText, MenuItem, Select, Stack, TextareaAutosize, TextField, Typography } from '@mui/material';
+import { CreateResponse, UpdateResponse } from '@refinedev/core';
+import React, { FormEventHandler } from 'react'
+import { FieldValues } from 'react-hook-form';
+import CustomButton from './CustomButton';
+import { FormProps } from '../../interfaces/home';
 
-function Form() {
+
+const Form = ({
+    type,
+    register,
+    onFinish,
+    formLoading,
+    handleSubmit,
+    handleImageChange,
+    onFinishHandler,
+    propertyImages,
+}: FormProps) => {
   return (
-    <div>
-      
-    </div>
+    <Box>
+      <Typography fontSize={25} fontWeight={700} color='#11142d'>
+        {type} a Property
+      </Typography>
+      <Box
+      mt={2.5}
+      borderRadius={"15px"}
+      padding={"20px"}
+      bgcolor={'#fcfcfc'}
+      >
+        <form
+          style={{
+          marginTop:"20px",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          gap: "20px"  
+        }}
+        // onSubmit={handleSubmit(onFinishHandler)}
+        >
+          <FormControl>
+            <FormHelperText
+            sx={{
+              fontWeight: 500,
+              margin: "10px 0",
+              fontSize: 16,
+              color:"#11142d"
+            }}
+            >
+              Enter properties name
+            </FormHelperText>
+            <TextField 
+            fullWidth 
+            required 
+            color='info' 
+            variant='outlined' 
+            {...register("title", { required: true })}
+            />
+          </FormControl>
+          <FormControl>
+            <FormHelperText
+            sx={{
+              fontWeight: 500,
+              margin: "10px 0",
+              fontSize: 16,
+              color:"#11142d"
+            }}
+            >
+              Enter properties description
+            </FormHelperText>
+            <TextareaAutosize
+            minRows={5}
+            required
+            color='info'
+            style={{
+              width: "100%",
+              background:"transparent",
+              borderColor:"rgba(0,0,0,0.23)",
+              borderRadius:"6",
+              padding: 10,
+              color:"#919191"
+            }}
+            {...register("description", { required: true })}
+            ></TextareaAutosize>
+          </FormControl>
+          <Stack direction={"row"} gap={4}>
+            <FormControl sx={{ flex: 1 }}>
+              <FormHelperText
+              sx={{
+              fontWeight: 500,
+              margin: "10px 0",
+              fontSize: 16,
+              color:"#11142d"
+              }}
+              >
+                Select Property Type
+              </FormHelperText>
+              <Select
+              variant='outlined'
+              color='info'
+              displayEmpty
+              required
+              inputProps={{"aria-label":"Without label"}}
+              defaultValue="apartment"
+              sx={{ textTransform: "capitalize" }}
+              {...register("propertyType", { required: true })}
+              >
+                <MenuItem value="farmhouse">Farmhouse</MenuItem>
+                <MenuItem value="condo">Condo</MenuItem>
+                <MenuItem value="studio">Studio</MenuItem>
+                <MenuItem value="apartment">Apartment</MenuItem>
+                <MenuItem value="villa">Villa</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl>
+              <FormHelperText
+              sx={{
+              fontWeight: 500,
+              margin: "10px 0",
+              fontSize: 16,
+              color:"#11142d"
+              }}
+              >
+                Enter Property Price
+              </FormHelperText>
+              <TextField 
+              fullWidth 
+              required 
+              color='info' 
+              variant='outlined' 
+              placeholder='Enter Price'
+              {...register("price", { required: true })}
+              />
+            </FormControl>
+          </Stack>
+          <FormControl>
+            <FormHelperText
+              sx={{
+              fontWeight: 500,
+              margin: "10px 0",
+              fontSize: 16,
+              color:"#11142d"
+              }}
+              >
+                Enter Property Location
+              </FormHelperText>
+              <TextField 
+              fullWidth 
+              required 
+              color='info' 
+              variant='outlined' 
+              placeholder='Enter Location'
+              {...register("location", { required: true })}
+              />
+          </FormControl>
+          <Stack
+          direction={"column"}
+          gap={1}
+          justifyContent={"center"}
+          mt={2}
+          >
+            <Stack direction={"row"} gap={2}>
+              <Typography color='#11142d' fontSize={'16px'} fontWeight={500} my={"10px"}>
+                Property Photo
+              </Typography>
+              <Button component="label"
+              sx={{
+                width: "fit-content",
+                color: "#2ed480",
+                textTransform: "capitalize",
+                fontSize: "16"
+              }}
+              >
+                Upload *
+                <input hidden type='file'
+                accept='image/*'
+                onChange={(e:React.ChangeEvent<HTMLInputElement>)=> {
+                  handleImageChange(e.target.files![0]);
+                }}
+                />
+              </Button>
+
+            </Stack>
+            <Typography 
+            fontSize={14} 
+            color={'#808191'}
+            sx={{
+              wordBreak: "break-all"
+            }}
+            >
+              {propertyImages?.name || "No image selected"}
+            </Typography>
+          </Stack>
+          <CustomButton 
+          type='submit'
+          title={formLoading ? "Submitting.." : "Submit"}
+          backgroundColor='#475be8'
+          color='#fcfcfc'
+          />
+        </form>
+      </Box>
+    </Box>
   )
 }
 

--- a/src/interfaces/home.d.ts
+++ b/src/interfaces/home.d.ts
@@ -4,3 +4,18 @@ export interface PieChartProps {
     series: Array<number>;
     colors: Array<string>;
 }
+
+export interface FormProps {
+  type: string;
+  register: any;
+  onFinish: (
+    values: FieldValues,
+  ) => Promise<void | CreateResponse | UpdateResponse>;
+  formLoading: boolean;
+  handleSubmit: FormEventHandler<HTMLFormElement> | undefined;
+  handleImageChange: (file: any) => void;
+  onFinishHandler: (
+    values: FieldValues,
+  ) => Promise<void> | void;
+  propertyImages: { name:string; url: string };
+}

--- a/src/pages/AllProperties.tsx
+++ b/src/pages/AllProperties.tsx
@@ -1,10 +1,18 @@
 import React from 'react'
+import { CustomButton } from '../components'
+import { useNavigate } from 'react-router'
+import { Add } from '@mui/icons-material';
 
-function AllProperties() {
+const AllProperties= () => {
+  const navigate = useNavigate();
   return (
-    <div>
-      <h1>AllProperties</h1>
-    </div>
+    <CustomButton 
+    title='Add Property'
+    handleClick={() => navigate("/properties/create")}
+    backgroundColor='#475be8'
+    color='#fcfcfc'
+    icon={<Add />}
+    />
   )
 }
 

--- a/src/pages/CreateProperties.tsx
+++ b/src/pages/CreateProperties.tsx
@@ -1,11 +1,51 @@
-import React from 'react'
+import { useGetIdentity } from '@refinedev/core'
+import React, { useState } from 'react'
+import { FieldValues } from 'react-hook-form';
+import Form from '../components/common/Form';
+import { useForm } from '@refinedev/react-hook-form';
 
-function CreateProperties() {
-  return (
-    <div>
-      <h1>CreateProperties</h1>
-    </div>
-  )
+const CreateProperties = () => {
+  const { data: user } = useGetIdentity({
+    v3LegacyAuthProviderCompatible: true
+  });
+  const [propertyImages,setPropertyImage] = useState<{ name: string; url: string }>({ name: "", url: "" });
+  const {
+    refineCore: { onFinish, formLoading },
+    register,
+    handleSubmit
+  } = useForm();
+  const handleImageChange = (file: File) => {
+    const reader = (readFile:File)=>{
+      return new Promise<string>((resolve, reject)=>{
+        const fileReader = new FileReader();
+        fileReader.onload = ()=> resolve(fileReader.result as string);
+        fileReader.readAsDataURL(readFile);
+      });
+    };
+    reader(file).then((result:string) => {
+      setPropertyImage ({ name: file?.name, url: result });
+    });
+  };
+
+  const onFinishHandler = async (data: FieldValues) => {
+    if(!propertyImages.name) return alert ("Please upload an image")
+      await onFinish({
+        ...data,
+        photo: propertyImages.url,
+        email: user?.email,
+    })
+  }
+
+  return <Form 
+  type="Create" 
+  register={register}
+  onFinish={onFinish}
+  formLoading={formLoading}
+  handleSubmit={handleSubmit}
+  handleImageChange={handleImageChange}
+  onFinishHandler={onFinishHandler}
+  propertyImages={propertyImages}
+  />;
 }
 
 export default CreateProperties


### PR DESCRIPTION
## What’s done
- Added reusable CustomButton component
- Integrated into /property Add Property page

## How to test
- Go to /properties/create
- Click Upload button